### PR TITLE
:construction_worker: Update CI workflow to build executables for both linux and windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ permissions:
   contents: write
 
 jobs:
-  build:
-    name: Build Exe
+  build-linux:
+    name: Build Linux
     runs-on: ubuntu-latest
 
     steps:
@@ -22,8 +22,24 @@ jobs:
 
       - run: pip install -r requirements.txt pyinstaller
       - run: pyinstaller --onefile export.py --collect-all pyfiglet --name "GCBE"
+      - name: Release Linux Artifacts
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: dist/GCBE
 
-      - name: Release Artifacts
+  build-windows:
+    name: Build Windows Exe
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.13.3
+      - run: pip install -r requirements.txt pyinstaller
+      - run: pyinstaller --onefile export.py --collect-all pyfiglet --name "GCBE"
+      - name: Release Windows Artifacts
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/build.yml` to separate the build process for Linux and Windows environments, improving clarity and supporting platform-specific releases.

### Workflow improvements:
* Split the `build` job into two separate jobs: `build-linux` (for Linux) and `build-windows` (for Windows), each with its own configuration and steps. This allows for better platform-specific handling.
* Added a `Release Linux Artifacts` step under the `build-linux` job to upload Linux-specific build artifacts when a tag is pushed.
* Configured the new `build-windows` job to run on `windows-latest`, including steps for Python setup, dependency installation, and artifact release for Windows builds.