### PR TITLE
:package: Add Renovate configuration for dependency management

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "major": {
+    "automerge": false
+  },
+  "reviewers": ["IamPekka058"],
+  "labels": [
+    "📌 Dependencies"
+  ],
+  "commitMessagePrefix": "⬆️",
+  "commitMessageAction": "Upgrade",
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "pin"
+      ],
+      "commitMessagePrefix": "📌",
+      "commitMessageAction": "Pin"
+    },
+    {
+      "matchUpdateTypes": [
+        "rollback"
+      ],
+      "commitMessagePrefix": "⬇️",
+      "commitMessageAction": "Downgrade"
+    },
+    {
+      "enabled": false
+    }
+  ],
+  "dependencyDashboardTitle": "📌 Dependency Dashboard",
+  "dependencyDashboardLabels": [
+    "📌 Dependencies"
+  ]
+}


### PR DESCRIPTION
This pull request adds a new `renovate.json` configuration file to set up and customize Renovate bot for dependency management. The configuration includes settings for commit message formatting, reviewer assignment, labels, and package-specific rules.

Key changes in Renovate bot configuration:

* Added a new `.github/renovate.json` file with the following configurations:
  - Extended the recommended Renovate bot configuration (`config:recommended`).
  - Disabled automerging for major updates and assigned "IamPekka058" as the reviewer for all dependency updates.
  - Added labels (`📌 Dependencies`) and customized commit message prefixes/actions for different update types (e.g., "Upgrade," "Pin," "Downgrade").
  - Included a dependency dashboard with a custom title and labels for tracking updates.