### PR TITLE
:package: Remove unused Renovate configuration for disabled updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,9 +26,6 @@
       ],
       "commitMessagePrefix": "⬇️",
       "commitMessageAction": "Downgrade"
-    },
-    {
-      "enabled": false
     }
   ],
   "dependencyDashboardTitle": "📌 Dependency Dashboard",


### PR DESCRIPTION
This pull request includes a minor update to the `.github/renovate.json` configuration file. The change removes an unused and disabled configuration block, simplifying the file.